### PR TITLE
Implemented Scroll to top 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import NotPages from "./NotPages.jsx";
 import Orders from "./landingPage/cart/Orders.jsx";
 import OnTopBar from "./landingPage/OnTopBar.jsx";
 import ShopNow from "./landingPage/fashions/ShopNow.jsx";
+import ScrollToTop from "./scrolltotop.jsx";
 
 
 
@@ -24,6 +25,7 @@ function App() {
   return (
     
       <BrowserRouter basename="/">
+      <ScrollToTop/>
        <Routes>
         <Route path="/" element={<HeroRoute />} />
         <Route path="/about" element={<About />} />

--- a/src/scrolltotop.jsx
+++ b/src/scrolltotop.jsx
@@ -1,0 +1,13 @@
+// src/ScrollToTop.jsx
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
Issue: #26 

Description
This PR fixes the issue where the scroll position was being retained when navigating between pages.
Previously, if a user scrolled down on one page and navigated to another, the new page would load at the same scroll position, which caused confusion and poor user experience.
I implemented a ScrollToTop component that resets the scroll position to the top (scrollY = 0) on every route change.

Changes Made
Added a ScrollToTop component using useLocation from react-router-dom.
Wrapped the <Routes> inside App.jsx with ScrollToTop to ensure scroll resets on every navigation.

Expected Behavior After Fix
On navigating to a new page, the view will always start at the top.
Improves overall navigation flow and user experience.